### PR TITLE
Added possibility to install artifacts.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,11 +114,11 @@ add_dependencies(laserscan_virtualizer ${PROJECT_NAME}_gencfg)
 # )
 
 ## Mark executables and/or libraries for installation
-# install(TARGETS laser_merger laser_merger_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
+install(TARGETS laserscan_multi_merger laserscan_virtualizer
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
 
 ## Mark cpp header files for installation
 # install(DIRECTORY include/${PROJECT_NAME}/
@@ -128,11 +128,9 @@ add_dependencies(laserscan_virtualizer ${PROJECT_NAME}_gencfg)
 # )
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
+install(DIRECTORY launch/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+)
 
 #############
 ## Testing ##


### PR DESCRIPTION
We are using your tools for merging front and rear laser on our robot platform BIRON. It works really great, but we need to install the artefacts (binaries and launch files) to our distribution volume. The committed change allows cmake to do so. Maybe others are interested in this fix as well.