### PR TITLE
Fixed the way topics were being read in

### DIFF
--- a/src/laserscan_multi_merger.cpp
+++ b/src/laserscan_multi_merger.cpp
@@ -9,7 +9,7 @@
 #include <pcl/io/pcd_io.h>
 #include <sensor_msgs/PointCloud.h>
 #include <sensor_msgs/PointCloud2.h>
-#include <sensor_msgs/point_cloud_conversion.h> 
+#include <sensor_msgs/point_cloud_conversion.h>
 #include "sensor_msgs/LaserScan.h"
 #include "pcl_ros/point_cloud.h"
 #include <Eigen/Dense>
@@ -54,7 +54,7 @@ private:
     string destination_frame;
     string cloud_destination_topic;
     string scan_destination_topic;
-    string laserscan_topics;
+    vector<string> laserscan_topics;
 };
 
 void LaserscanMerger::reconfigureCallback(laserscan_multi_mergerConfig &config, uint32_t level)
@@ -70,57 +70,16 @@ void LaserscanMerger::reconfigureCallback(laserscan_multi_mergerConfig &config, 
 
 void LaserscanMerger::laserscan_topic_parser()
 {
-	// LaserScan topics to subscribe
-	ros::master::V_TopicInfo topics;
-	ros::master::getTopics(topics);
-
-    istringstream iss(laserscan_topics);
-	vector<string> tokens;
-	copy(istream_iterator<string>(iss), istream_iterator<string>(), back_inserter<vector<string> >(tokens));
-
-	vector<string> tmp_input_topics;
-
-	for(int i=0;i<tokens.size();++i)
-	{
-	        for(int j=0;j<topics.size();++j)
-		{
-			if( (tokens[i].compare(topics[j].name) == 0) && (topics[j].datatype.compare("sensor_msgs/LaserScan") == 0) )
-			{
-				tmp_input_topics.push_back(topics[j].name);
-			}
-		}
-	}
-
-	sort(tmp_input_topics.begin(),tmp_input_topics.end());
-	std::vector<string>::iterator last = std::unique(tmp_input_topics.begin(), tmp_input_topics.end());
-	tmp_input_topics.erase(last, tmp_input_topics.end());
-
-
-	// Do not re-subscribe if the topics are the same
-	if( (tmp_input_topics.size() != input_topics.size()) || !equal(tmp_input_topics.begin(),tmp_input_topics.end(),input_topics.begin()))
-	{
-
-		// Unsubscribe from previous topics
-		for(int i=0; i<scan_subscribers.size(); ++i)
-			scan_subscribers[i].shutdown();
-
-		input_topics = tmp_input_topics;
-		if(input_topics.size() > 0)
-		{
-            scan_subscribers.resize(input_topics.size());
-			clouds_modified.resize(input_topics.size());
-			clouds.resize(input_topics.size());
-            ROS_INFO("Subscribing to topics\t%ld", scan_subscribers.size());
-			for(int i=0; i<input_topics.size(); ++i)
-			{
-                scan_subscribers[i] = node_.subscribe<sensor_msgs::LaserScan> (input_topics[i].c_str(), 1, boost::bind(&LaserscanMerger::scanCallback,this, _1, input_topics[i]));
-				clouds_modified[i] = false;
-				cout << input_topics[i] << " ";
-			}
-		}
-		else
-            ROS_INFO("Not subscribed to any topic.");
-	}
+    for(int i = 0; i < laserscan_topics.size(); ++i)
+    {
+        scan_subscribers.push_back(
+                node_.subscribe<sensor_msgs::LaserScan>(
+                    laserscan_topics[i].c_str(), 1,
+                    boost::bind(
+                        &LaserscanMerger::scanCallback,this,
+                        _1, laserscan_topics[i])));
+        clouds_modified.push_back(false);
+    }
 }
 
 LaserscanMerger::LaserscanMerger()
@@ -162,7 +121,7 @@ void LaserscanMerger::scanCallback(const sensor_msgs::LaserScan::ConstPtr& scan,
 			pcl_conversions::toPCL(tmpCloud3, clouds[i]);
 			clouds_modified[i] = true;
 		}
-	}	
+	}
 
     // Count how many scans we have
 	int totalClouds = 0;
@@ -181,7 +140,7 @@ void LaserscanMerger::scanCallback(const sensor_msgs::LaserScan::ConstPtr& scan,
 			pcl::concatenatePointCloud(merged_cloud, clouds[i], merged_cloud);
 			clouds_modified[i] = false;
 		}
-	
+
 		point_cloud_publisher_.publish(merged_cloud);
 
 		Eigen::MatrixXf points;

--- a/src/laserscan_multi_merger.cpp
+++ b/src/laserscan_multi_merger.cpp
@@ -39,7 +39,6 @@ private:
     vector<bool> clouds_modified;
 
     vector<pcl::PCLPointCloud2> clouds;
-    vector<string> input_topics;
 
     void laserscan_topic_parser();
 
@@ -80,6 +79,7 @@ void LaserscanMerger::laserscan_topic_parser()
                         _1, laserscan_topics[i])));
         clouds_modified.push_back(false);
     }
+    clouds = vector<pcl::PCLPointCloud2>(laserscan_topics.size());
 }
 
 LaserscanMerger::LaserscanMerger()
@@ -113,9 +113,9 @@ void LaserscanMerger::scanCallback(const sensor_msgs::LaserScan::ConstPtr& scan,
 		tfListener_.transformPointCloud(destination_frame.c_str(), tmpCloud1, tmpCloud2);
 	}catch (tf::TransformException ex){ROS_ERROR("%s",ex.what());return;}
 
-	for(int i=0; i<input_topics.size(); ++i)
+	for(int i=0; i<laserscan_topics.size(); ++i)
 	{
-		if(topic.compare(input_topics[i]) == 0)
+		if(topic.compare(laserscan_topics[i]) == 0)
 		{
 			sensor_msgs::convertPointCloudToPointCloud2(tmpCloud2,tmpCloud3);
 			pcl_conversions::toPCL(tmpCloud3, clouds[i]);
@@ -126,8 +126,12 @@ void LaserscanMerger::scanCallback(const sensor_msgs::LaserScan::ConstPtr& scan,
     // Count how many scans we have
 	int totalClouds = 0;
 	for(int i=0; i<clouds_modified.size(); ++i)
+    {
 		if(clouds_modified[i])
+        {
 			++totalClouds;
+        }
+    }
 
     // Go ahead only if all subscribed scans have arrived
 	if(totalClouds == clouds_modified.size())


### PR DESCRIPTION
I changed the way we are reading in topics. Before it was using a space separated string that was also being checked against currently alive topics. I removed the checking to make it easier to use for more asynchronous systems, and I am using the common standard for lists to enter the list of scan topics. This is shown below:

```
<rosparam>
    laserscan_topics:
        - /scan_topic
        - /another_scan_topic
</rosparam>
```
