### PR TITLE
add libvtk-qt dependency to fix debian stretch builds

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -24,4 +24,8 @@
   <run_depend>laser_geometry</run_depend>
   <run_depend>roscpp</run_depend>
 
+  <!-- Needed to work around https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=894656 on Debian Stretch -->
+  <build_depend>libvtk-qt</build_depend>
+  <run_depend>libvtk-qt</run_depend>
+  
 </package>


### PR DESCRIPTION
`libpcl-dev` is [missing a dependency on libvtk6-qt-dev](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=894656) on debian stretch causing the [builds to fail](http://build.ros.org/view/Lbin_ds_dS64/job/Lbin_ds_dS64__ira_laser_tools__debian_stretch_amd64__binary/4/).

This PR adds the missing dependency manually to fix the builds.