### PR TITLE
Remove dependencies on non-existing package "pcl"

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,14 +10,12 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>pcl</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>laser_geometry</build_depend>
   <build_depend>roscpp</build_depend>
   <run_depend>sensor_msgs</run_depend>
-  <run_depend>pcl</run_depend>
   <run_depend>pcl_ros</run_depend>
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>


### PR DESCRIPTION
This causes problems when automatic resolving dependencies. As far as I am aware off there is no package "pcl".