### PR TITLE
fix merge failed when launch merger faster than laser

### DIFF
--- a/src/laserscan_multi_merger.cpp
+++ b/src/laserscan_multi_merger.cpp
@@ -39,7 +39,6 @@ private:
     vector<bool> clouds_modified;
 
     vector<pcl::PCLPointCloud2> clouds;
-    vector<string> input_topics;
 
     void laserscan_topic_parser();
 
@@ -70,55 +69,18 @@ void LaserscanMerger::reconfigureCallback(laserscan_multi_mergerConfig &config, 
 
 void LaserscanMerger::laserscan_topic_parser()
 {
-	// LaserScan topics to subscribe
-	ros::master::V_TopicInfo topics;
-	ros::master::getTopics(topics);
-
     istringstream iss(laserscan_topics);
-	vector<string> tokens;
-	copy(istream_iterator<string>(iss), istream_iterator<string>(), back_inserter<vector<string> >(tokens));
-	vector<string> tmp_input_topics;
-	for(int i=0;i<tokens.size();++i)
-	{
-        for(int j=0;j<topics.size();++j)
-		{
-			if( (tokens[i].compare(topics[j].name) == 0) && (topics[j].datatype.compare("sensor_msgs/LaserScan") == 0) )
-			{
-				tmp_input_topics.push_back(topics[j].name);
-			}
-		}
-	}
+	for(string input_topic; iss>>input_topic;){
+    	scan_subscribers.push_back(node_.subscribe<sensor_msgs::LaserScan>(
+        	input_topic, 1, boost::bind(&LaserscanMerger::scanCallback, this, _1, input_topic)));
+        
+    }
+    if (scan_subscribers.empty())
+        ROS_WARN("Not subscribed to any topic.");
 
-	sort(tmp_input_topics.begin(),tmp_input_topics.end());
-	std::vector<string>::iterator last = std::unique(tmp_input_topics.begin(), tmp_input_topics.end());
-	tmp_input_topics.erase(last, tmp_input_topics.end());
-
-
-	// Do not re-subscribe if the topics are the same
-	if( (tmp_input_topics.size() != input_topics.size()) || !equal(tmp_input_topics.begin(),tmp_input_topics.end(),input_topics.begin()))
-	{
-
-		// Unsubscribe from previous topics
-		for(int i=0; i<scan_subscribers.size(); ++i)
-			scan_subscribers[i].shutdown();
-
-		input_topics = tmp_input_topics;
-		if(input_topics.size() > 0)
-		{
-            scan_subscribers.resize(input_topics.size());
-			clouds_modified.resize(input_topics.size());
-			clouds.resize(input_topics.size());
-            ROS_INFO("Subscribing to topics\t%ld", scan_subscribers.size());
-			for(int i=0; i<input_topics.size(); ++i)
-			{
-                scan_subscribers[i] = node_.subscribe<sensor_msgs::LaserScan> (input_topics[i].c_str(), 1, boost::bind(&LaserscanMerger::scanCallback,this, _1, input_topics[i]));
-				clouds_modified[i] = false;
-				cout << input_topics[i] << " ";
-			}
-		}
-		else
-            ROS_INFO("Not subscribed to any topic.");
-	}
+    ROS_INFO("Subscribing to topics\t%ld", scan_subscribers.size());
+    clouds_modified = vector<bool>(scan_subscribers.size(), false);
+    clouds.resize(scan_subscribers.size());
 }
 
 LaserscanMerger::LaserscanMerger()
@@ -156,12 +118,14 @@ void LaserscanMerger::scanCallback(const sensor_msgs::LaserScan::ConstPtr& scan,
 		tfListener_.transformPointCloud(destination_frame.c_str(), tmpCloud1, tmpCloud2);
 	}catch (tf::TransformException ex){ROS_ERROR("%s",ex.what());return;}
 
-	for(int i=0; i<input_topics.size(); ++i)
+	for(int i=0; i<scan_subscribers.size(); ++i)
 	{
-		if(topic.compare(input_topics[i]) == 0)
+		if(topic.compare(scan_subscribers[i].getTopic()) == 0)
 		{
 			sensor_msgs::convertPointCloudToPointCloud2(tmpCloud2,tmpCloud3);
 			pcl_conversions::toPCL(tmpCloud3, clouds[i]);
+			clouds_modified[i] = true;
+		}else if(scan_subscribers[i].getNumPublishers() == 0){
 			clouds_modified[i] = true;
 		}
 	}	


### PR DESCRIPTION
Related Issues or PRs
#5 #16 #17 (maybe #32)

#16 and #17 have a problem.
These PRs never merge when `laserscan_topics` contained one or more unknown topics.
To prevent it, when triggered scanCallback by one of subscribers, `clouds_modified` that the topic has no publisher set to true.

I hope this package works better regardless of launch order and makes this package more convenience.