### PR TITLE
Retrying compare topics between ROS master and Token

### DIFF
--- a/src/laser_multi_merger.cpp
+++ b/src/laser_multi_merger.cpp
@@ -83,6 +83,21 @@ void LaserMerger::reconfigureCallback(laser_multi_mergerConfig &config, uint32_t
 			}
 		}
 	}
+	while(tmp_input_topics.size() != tokens.size()) {
+		ROS_INFO("CAN NOT MATCH TOPIC BETWEEN ROS MASTER AND GIVEN TOPICS. RETRYING");
+		sleep(1);
+		ros::master::getTopics(topics);
+		for(int i=0;i<tokens.size();++i)
+		{
+			for(int j=0;j<topics.size();++j)
+			{
+				if( (tokens[i].compare(topics[j].name) == 0) && (topics[j].datatype.compare("sensor_msgs/LaserScan") == 0) )
+				{
+					tmp_input_topics.push_back(topics[j].name);
+				}
+			}
+		}
+	}
 
 	sort(tmp_input_topics.begin(),tmp_input_topics.end());
 	std::vector<string>::iterator last = std::unique(tmp_input_topics.begin(), tmp_input_topics.end());


### PR DESCRIPTION
If laser merger launched before lidar nodes, the merger will do nothing.
So I added the while loop to retrying compare topics until topics is compared correctly.