### PR TITLE
Merge pointclouds from different topics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(PCL REQUIRED)
 #   "<command-line>:0:0: warning: missing whitespace after the macro name"
 remove_definitions(-DDISABLE_LIBUSB-1.0)
 
-generate_dynamic_reconfigure_options(cfg/laserscan_multi_merger.cfg cfg/laserscan_virtualizer.cfg)
+generate_dynamic_reconfigure_options(cfg/laserscan_multi_merger.cfg cfg/pointcloud_multi_merger.cfg cfg/laserscan_virtualizer.cfg)
 
 
 ## System dependencies are found with CMake's conventions
@@ -91,9 +91,13 @@ include_directories(include
 add_executable(laserscan_multi_merger src/laserscan_multi_merger.cpp)
 target_link_libraries(laserscan_multi_merger ${catkin_LIBRARIES} ${PCL_LIBRARIES})
 
+add_executable(pointcloud_multi_merger src/pointcloud_multi_merger.cpp)
+target_link_libraries(pointcloud_multi_merger ${catkin_LIBRARIES} ${PCL_LIBRARIES})
+
 ## Add cmake target dependencies of the executable/library
 ## as an example, message headers may need to be generated before nodes
 add_dependencies(laserscan_multi_merger ${PROJECT_NAME}_gencfg)
+add_dependencies(pointcloud_multi_merger ${PROJECT_NAME}_gencfg)
 
 add_executable(laserscan_virtualizer src/laserscan_virtualizer.cpp)
 target_link_libraries(laserscan_virtualizer ${catkin_LIBRARIES} ${PCL_LIBRARIES})
@@ -120,7 +124,7 @@ add_dependencies(laserscan_virtualizer ${PROJECT_NAME}_gencfg)
 # )
 
 ## Mark executables and/or libraries for installation
-install(TARGETS laserscan_multi_merger laserscan_virtualizer
+install(TARGETS laserscan_multi_merger pointcloud_multi_merger laserscan_virtualizer
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}

--- a/cfg/pointcloud_multi_merger.cfg
+++ b/cfg/pointcloud_multi_merger.cfg
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+PACKAGE = "pointcloud_multi_merger"
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+import math
+
+gen = ParameterGenerator()
+
+gen.add("angle_min", double_t, 0, "Minimum angle of the output scan", -2.36, -math.pi, math.pi)
+gen.add("angle_max", double_t, 0, "Maximum angle of the output scan", 2.36, -math.pi, math.pi)
+gen.add("angle_increment", double_t, 0, "Angle increment of the output scan", 0.0058, 0, math.pi)
+gen.add("time_increment", double_t, 0, "Time increment of the output scan", 0.0, 0, 1)
+gen.add("scan_time", double_t, 0, "Scan time of the output scan", 0.033333333, 0, 1)
+gen.add("range_min", double_t, 0, "Range min of the output scan", 0.45, 0, 50)
+gen.add("range_max", double_t, 0, "Range max of the output scan", 25.0, 0, 1000)
+
+exit(gen.generate(PACKAGE, "pointcloud_multi_merger", "pointcloud_multi_merger"))

--- a/launch/pointcloud_multi_merger.launch
+++ b/launch/pointcloud_multi_merger.launch
@@ -4,7 +4,7 @@ DESCRITPION
 
 
 <launch>
-  <arg name="pointcloud_topics" default="/scanner_front/cloud /scanner_back/cloud" />
+  <arg name="pointcloud_topics" default="/clouda/cloudb" />
 
   <node pkg="ira_laser_tools" name="pointcloud_multi_merger" type="pointcloud_multi_merger" output="screen">
     <param name="destination_frame" value="base_link"/>

--- a/launch/pointcloud_multi_merger.launch
+++ b/launch/pointcloud_multi_merger.launch
@@ -1,0 +1,20 @@
+<!--
+DESCRITPION
+-->
+
+
+<launch>
+  <arg name="pointcloud_topics" default="/scanner_front/cloud /scanner_back/cloud" />
+
+  <node pkg="ira_laser_tools" name="pointcloud_multi_merger" type="pointcloud_multi_merger" output="screen">
+    <param name="destination_frame" value="base_link"/>
+    <param name="cloud_destination_topic" value="/merged_pcd"/>
+    <param name="pointcloud_topics" value ="$(arg pointcloud_topics)" /> <!-- LIST OF THE LASER SCAN TOPICS TO SUBSCRIBE -->
+    <param name="angle_min" value="-2.0"/>
+    <param name="angle_max" value="2.0"/>
+    <param name="angle_increment" value="0.0058"/>
+    <param name="scan_time" value="0.0333333"/>
+    <param name="range_min" value="0.30"/>
+    <param name="range_max" value="50.0"/>
+  </node>
+</launch>

--- a/src/pointcloud_multi_merger.cpp
+++ b/src/pointcloud_multi_merger.cpp
@@ -2,7 +2,6 @@
 #include <string.h>
 #include <tf/transform_listener.h>
 #include <pcl_ros/transforms.h>
-#include <laser_geometry/laser_geometry.h>
 #include <pcl/conversions.h>
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
@@ -10,7 +9,6 @@
 #include <sensor_msgs/PointCloud.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <sensor_msgs/point_cloud_conversion.h> 
-#include "sensor_msgs/LaserScan.h"
 #include "pcl_ros/point_cloud.h"
 #include <Eigen/Dense>
 #include <dynamic_reconfigure/server.h>
@@ -66,7 +64,7 @@ void PointCloudMerger::reconfigureCallback(pointcloud_multi_mergerConfig &config
 
 void PointCloudMerger::pointcloud_topic_parser()
 {
-	// LaserScan topics to subscribe
+	// PointCloud topics to subscribe
 	ros::master::V_TopicInfo topics;
 	ros::master::getTopics(topics);
 

--- a/src/pointcloud_multi_merger.cpp
+++ b/src/pointcloud_multi_merger.cpp
@@ -1,0 +1,197 @@
+#include <ros/ros.h>
+#include <string.h>
+#include <tf/transform_listener.h>
+#include <pcl_ros/transforms.h>
+#include <laser_geometry/laser_geometry.h>
+#include <pcl/conversions.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl/io/pcd_io.h>
+#include <sensor_msgs/PointCloud.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/point_cloud_conversion.h> 
+#include "sensor_msgs/LaserScan.h"
+#include "pcl_ros/point_cloud.h"
+#include <Eigen/Dense>
+#include <dynamic_reconfigure/server.h>
+#include <ira_laser_tools/pointcloud_multi_mergerConfig.h>
+
+using namespace std;
+using namespace pcl;
+using namespace pointcloud_multi_merger;
+
+class PointCloudMerger
+{
+public:
+    PointCloudMerger();
+    void pointCloudCallback(const sensor_msgs::PointCloud2::ConstPtr& pcd, std::string topic);
+    void reconfigureCallback(pointcloud_multi_mergerConfig &config, uint32_t level);
+
+private:
+    ros::NodeHandle node_;
+    tf::TransformListener tfListener_;
+
+    ros::Publisher point_cloud_publisher_;
+    vector<ros::Subscriber> cloud_subscribers;
+    vector<bool> clouds_modified;
+
+    vector<pcl::PCLPointCloud2> clouds;
+    vector<string> input_topics;
+
+    void pointcloud_topic_parser();
+
+    double angle_min;
+    double angle_max;
+    double angle_increment;
+    double time_increment;
+    double scan_time;
+    double range_min;
+    double range_max;
+
+    string destination_frame;
+    string cloud_destination_topic;
+    string pointcloud_topics;
+};
+
+void PointCloudMerger::reconfigureCallback(pointcloud_multi_mergerConfig &config, uint32_t level)
+{
+	this->angle_min = config.angle_min;
+	this->angle_max = config.angle_max;
+	this->angle_increment = config.angle_increment;
+	this->time_increment = config.time_increment;
+	this->scan_time = config.scan_time;
+	this->range_min = config.range_min;
+	this->range_max = config.range_max;
+}
+
+void PointCloudMerger::pointcloud_topic_parser()
+{
+	// LaserScan topics to subscribe
+	ros::master::V_TopicInfo topics;
+	ros::master::getTopics(topics);
+
+    istringstream iss(pointcloud_topics);
+	vector<string> tokens;
+	copy(istream_iterator<string>(iss), istream_iterator<string>(), back_inserter<vector<string> >(tokens));
+	vector<string> tmp_input_topics;
+	for(int i=0;i<tokens.size();++i)
+	{
+        for(int j=0;j<topics.size();++j)
+		{
+			if( (tokens[i].compare(topics[j].name) == 0) && (topics[j].datatype.compare("sensor_msgs/PointCloud2") == 0) )
+			{
+				tmp_input_topics.push_back(topics[j].name);
+			}
+		}
+	}
+
+	sort(tmp_input_topics.begin(),tmp_input_topics.end());
+	std::vector<string>::iterator last = std::unique(tmp_input_topics.begin(), tmp_input_topics.end());
+	tmp_input_topics.erase(last, tmp_input_topics.end());
+
+
+	// Do not re-subscribe if the topics are the same
+	if( (tmp_input_topics.size() != input_topics.size()) || !equal(tmp_input_topics.begin(),tmp_input_topics.end(),input_topics.begin()))
+	{
+
+		// Unsubscribe from previous topics
+		for(int i=0; i<cloud_subscribers.size(); ++i)
+			cloud_subscribers[i].shutdown();
+
+		input_topics = tmp_input_topics;
+		if(input_topics.size() > 0)
+		{
+            cloud_subscribers.resize(input_topics.size());
+			clouds_modified.resize(input_topics.size());
+			clouds.resize(input_topics.size());
+            ROS_INFO("Subscribing to topics\t%ld", cloud_subscribers.size());
+			for(int i=0; i<input_topics.size(); ++i)
+			{
+                cloud_subscribers[i] = node_.subscribe<sensor_msgs::PointCloud2> (input_topics[i].c_str(), 1, boost::bind(&PointCloudMerger::pointCloudCallback,this, _1, input_topics[i]));
+				clouds_modified[i] = false;
+				cout << input_topics[i] << " ";
+			}
+		}
+		else
+            ROS_INFO("Not subscribed to any topic.");
+	}
+}
+
+PointCloudMerger::PointCloudMerger()
+{
+	ros::NodeHandle nh("~");
+
+    nh.param<std::string>("destination_frame", destination_frame, "cart_frame");
+    nh.param<std::string>("cloud_destination_topic", cloud_destination_topic, "/merged_cloud");
+    nh.param<std::string>("pointcloud_topics", pointcloud_topics, "");
+    nh.param("angle_min", angle_min, -2.36);
+    nh.param("angle_max", angle_max, 2.36);
+    nh.param("angle_increment", angle_increment, 0.0058);
+    nh.param("scan_time", scan_time, 0.0333333);
+    nh.param("range_min", range_min, 0.45);
+    nh.param("range_max", range_max, 25.0);
+
+    this->pointcloud_topic_parser();
+
+	point_cloud_publisher_ = node_.advertise<sensor_msgs::PointCloud2> (cloud_destination_topic.c_str(), 1, false);
+
+}
+
+void PointCloudMerger::pointCloudCallback(const sensor_msgs::PointCloud2::ConstPtr& pcd, std::string topic)
+{
+	sensor_msgs::PointCloud2 tmpCloud;
+    tf::StampedTransform transform;
+
+	tfListener_.waitForTransform(pcd->header.frame_id.c_str(), destination_frame.c_str(), pcd->header.stamp, ros::Duration(10));
+	try
+	{
+	    pcl_ros::transformPointCloud(destination_frame.c_str(), *pcd, tmpCloud, tfListener_);
+	}catch (tf::TransformException ex){ROS_ERROR("%s",ex.what());return;}
+
+	for(int i=0; i<input_topics.size(); ++i)
+	{
+		if(topic.compare(input_topics[i]) == 0)
+		{
+			pcl_conversions::toPCL(tmpCloud, clouds[i]);
+			clouds_modified[i] = true;
+		}
+	}	
+
+    // Count how many clouds we have
+	int totalClouds = 0;
+	for(int i=0; i<clouds_modified.size(); ++i)
+		if(clouds_modified[i])
+			++totalClouds;
+
+    // Go ahead only if all subscribed clouds have arrived
+	if(totalClouds == clouds_modified.size())
+	{
+		pcl::PCLPointCloud2 merged_cloud = clouds[0];
+		clouds_modified[0] = false;
+
+		for(int i=1; i<clouds_modified.size(); ++i)
+		{
+			pcl::concatenatePointCloud(merged_cloud, clouds[i], merged_cloud);
+			clouds_modified[i] = false;
+		}
+	
+		point_cloud_publisher_.publish(merged_cloud);
+	}
+}
+
+int main(int argc, char** argv)
+{
+	ros::init(argc, argv, "pointcloud_multi_merger");
+
+    PointCloudMerger _pcd_merger;
+
+    dynamic_reconfigure::Server<pointcloud_multi_mergerConfig> server;
+    dynamic_reconfigure::Server<pointcloud_multi_mergerConfig>::CallbackType f;
+
+    f = boost::bind(&PointCloudMerger::reconfigureCallback,&_pcd_merger, _1, _2);
+	server.setCallback(f);
+
+	ros::spin();
+
+	return 0;
+}


### PR DESCRIPTION
I was looking for a utility to merge pointclouds coming from different 3D LiDARs placed on a robot. I saw that this package already contains a node to merge multiple laser scans. This PR adds the node `pointcloud_multi_merger` that takes in pointcloud from multiple topics and publishes the merged cloud.
I am not sure what would be the right configuration parameters here (similar to `laserscan_multi_merger.cfg`) so I have just used the same ones for this node.