### PR TITLE
Use the same header in published scan as the published cloud

### DIFF
--- a/src/laserscan_multi_merger.cpp
+++ b/src/laserscan_multi_merger.cpp
@@ -209,8 +209,6 @@ void LaserscanMerger::pointcloud_to_laserscan(Eigen::MatrixXf points, pcl::PCLPo
 {
 	sensor_msgs::LaserScanPtr output(new sensor_msgs::LaserScan());
 	output->header = pcl_conversions::fromPCL(merged_cloud->header);
-	output->header.frame_id = destination_frame.c_str();
-	output->header.stamp = ros::Time(0);  //fixes #265
 	output->angle_min = this->angle_min;
 	output->angle_max = this->angle_max;
 	output->angle_increment = this->angle_increment;


### PR DESCRIPTION
Thought it might make sense for these to match since they came from the same incoming data, also uses the data timestamp instead which might be useful. Happy to discuss or make changes upon request.